### PR TITLE
Fix #24: fails to install because of scheduled transitions permissions

### DIFF
--- a/localgov_blogs.install
+++ b/localgov_blogs.install
@@ -9,6 +9,17 @@ use Drupal\Core\Config\Config;
 use Symfony\Component\Yaml\Yaml;
 
 /**
+ * Implements hook_install().
+ */
+function localgov_blogs_install($is_syncing) {
+  // Configure scheduled transitions if enabled.
+  if (!$is_syncing && \Drupal::moduleHandler()->moduleExists('scheduled_transitions')) {
+    var_dump('install');
+    localgov_blogs_configure_scheduled_transitions();
+  }
+}
+
+/**
  * Add the new view for blog authors.
  */
 function localgov_blogs_update_8001() {

--- a/localgov_blogs.install
+++ b/localgov_blogs.install
@@ -14,7 +14,6 @@ use Symfony\Component\Yaml\Yaml;
 function localgov_blogs_install($is_syncing) {
   // Configure scheduled transitions if enabled.
   if (!$is_syncing && \Drupal::moduleHandler()->moduleExists('scheduled_transitions')) {
-    var_dump('install');
     localgov_blogs_configure_scheduled_transitions();
   }
 }

--- a/localgov_blogs.module
+++ b/localgov_blogs.module
@@ -263,15 +263,14 @@ function localgov_blogs_localgov_roles_default(): array {
 function localgov_blogs_configure_scheduled_transitions() {
   // Configure scheduled transitions for alert banners.
   $scheduled_transitions_config = \Drupal::service('config.factory')->getEditable('scheduled_transitions.settings');
-  $bundles = [
-    [
-      'entity_type' => 'node',
-      'bundle' => 'localgov_blog_channel',
-    ],
-    [
-      'entity_type' => 'node',
-      'bundle' => 'localgov_blog_post',
-    ],
+  $bundles = $scheduled_transitions_config->get('bundles');
+  $bundles[] = [
+    'entity_type' => 'node',
+    'bundle' => 'localgov_blog_channel',
+  ];
+  $bundles[] = [
+    'entity_type' => 'node',
+    'bundle' => 'localgov_blog_post',
   ];
   $scheduled_transitions_config->set('bundles', $bundles);
   $scheduled_transitions_config->save();

--- a/localgov_blogs.module
+++ b/localgov_blogs.module
@@ -5,12 +5,24 @@
  * LocalGov DrupalBlogs module file.
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\localgov_roles\RolesHelper;
 use Drupal\node\NodeForm;
 use Drupal\node\NodeInterface;
 use Drupal\views\Views;
+
+/**
+ * Implements hook_modules_installed().
+ */
+function localgov_blogs_modules_installed($modules, $is_syncing) {
+
+  // Configure scheduled transitions if it's being installed.
+  if (in_array('scheduled_transitions', $modules, TRUE)) {
+    localgov_blogs_configure_scheduled_transitions();
+  }
+}
 
 /**
  * Implements hook_entity_extra_field_info().
@@ -243,4 +255,29 @@ function localgov_blogs_localgov_roles_default(): array {
   }
 
   return $perms;
+}
+
+/**
+ * Configure scheduled transitions.
+ */
+function localgov_blogs_configure_scheduled_transitions() {
+  // Configure scheduled transitions for alert banners.
+  $scheduled_transitions_config = \Drupal::service('config.factory')->getEditable('scheduled_transitions.settings');
+  $bundles = [
+    [
+      'entity_type' => 'node',
+      'bundle' => 'localgov_blog_channel',
+    ],
+    [
+      'entity_type' => 'node',
+      'bundle' => 'localgov_blog_post',
+    ],
+  ];
+  $scheduled_transitions_config->set('bundles', $bundles);
+  $scheduled_transitions_config->save();
+
+  Cache::invalidateTags([
+    'scheduled_transition_settings',
+    'config:scheduled_transitions.settings',
+  ]);
 }


### PR DESCRIPTION
Based on what localgov alert banner does. This adds the scheduled transitions that the permissions are for in #24 

However now running `ddev drush si -y localgov; ddev drush en -y localgov_workflows; ddev drush en -y localgov_blogs;`
I get an error about _Services_ not having installed the workflow yet
```
  Adding non-existent permissions to a role is not allowed. The incorrect permissions are "add schedule  
  d transitions node localgov_services_landing", "add scheduled transitions node localgov_services_page  
  ", "add scheduled transitions node localgov_services_sublanding", "reschedule scheduled transitions n  
  ode localgov_services_landing", "reschedule scheduled transitions node localgov_services_page", "resc  
  hedule scheduled transitions node localgov_services_sublanding", "view scheduled transitions node loc  
  algov_services_landing", "view scheduled transitions node localgov_services_page", "view scheduled tr  
  ansitions node localgov_services_sublanding".    
```