### PR TITLE
fix: Read me typo on issues URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ composer require localgovdrupal/localgov_blogs:^1.0.0
 
 ## Issues
 
-If you run into issues using this module, please report them at https://github.com/localgovdrupal/localgov_blogss/issues
+If you run into issues using this module, please report them at https://github.com/localgovdrupal/localgov_blogs/issues
 
 ## Maintainers 
 


### PR DESCRIPTION
Minor update to Read Me - there was a typo issues URL (an extra s in "localgov_blogs")